### PR TITLE
feat: Add device theme detection support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,7 +339,7 @@ function App() {
         // In production, you might want to send this to an error tracking service
       }}
     >
-      <UIProvider initialTheme="light" initialDebugMode={false}>
+      <UIProvider initialDebugMode={false}>
         <ScheduleProvider>
           <ConfigurationProvider>
             <ProgressProvider>


### PR DESCRIPTION
## Description
This PR implements automatic theme detection based on the device's system preferences. The app will now respect the user's OS-level dark/light mode setting on initial load and respond to changes in real-time.

## Changes Made
- **System Theme Detection**: Uses `window.matchMedia('(prefers-color-scheme: dark)')` to detect system preference
- **Dynamic Updates**: Listens for system theme changes and updates automatically
- **User Override Support**: When user manually toggles theme, it stops following system changes
- **Browser Compatibility**: Supports both modern `addEventListener` and legacy `addListener` APIs
- **Removed Hardcoding**: Removed the hardcoded `initialTheme="light"` from App.tsx

## How It Works
1. On app load, checks system preference and sets initial theme accordingly
2. Sets up a listener for system theme changes
3. If user manually toggles theme, sets a flag to stop following system changes
4. Preserves user choice until they refresh the page

## Testing Instructions
1. Set your OS to dark mode → app should load in dark mode
2. Set your OS to light mode → app should load in light mode
3. Change OS theme while app is open → app theme should update
4. Manually toggle theme in app → app should stop following OS changes
5. Refresh page → app should again follow OS preference

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

/gemini review