### PR TITLE
fix: Remove legacy MediaQueryList methods to fix Vercel build

### DIFF
--- a/src/context/UIContext.tsx
+++ b/src/context/UIContext.tsx
@@ -252,7 +252,7 @@ export function UIProvider({
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-    const handleThemeChange = (e: MediaQueryListEvent | MediaQueryList) => {
+    const handleThemeChange = (e: MediaQueryListEvent) => {
       // Only update theme if user hasn't manually overridden it
       if (!hasUserOverride.current) {
         const newTheme: 'light' | 'dark' = e.matches ? 'dark' : 'light';

--- a/src/context/UIContext.tsx
+++ b/src/context/UIContext.tsx
@@ -264,19 +264,11 @@ export function UIProvider({
       }
     };
 
-    // Use addEventListener for modern browsers, addListener for legacy
-    if ('addEventListener' in mediaQuery) {
-      mediaQuery.addEventListener('change', handleThemeChange);
-      return () => {
-        mediaQuery.removeEventListener('change', handleThemeChange);
-      };
-    } else {
-      // Legacy browser support
-      mediaQuery.addListener(handleThemeChange);
-      return () => {
-        mediaQuery.removeListener(handleThemeChange);
-      };
-    }
+    // All modern browsers support addEventListener
+    mediaQuery.addEventListener('change', handleThemeChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleThemeChange);
+    };
   }, []);
 
   // View mode actions


### PR DESCRIPTION
## Description
This PR fixes the TypeScript build error that was causing Vercel deployments to fail.

## The Issue
TypeScript was complaining about  and  methods:
```
TS2339: Property 'addListener' does not exist on type 'never'.
```

## The Fix
Removed the legacy browser support code since:
- All modern browsers support  for MediaQueryList
- The legacy methods are deprecated and not in TypeScript types
- Supporting very old browsers isn't worth the complexity

## Testing
- Local build passes without errors
- Theme detection still works properly
- Vercel should now deploy successfully

/gemini review